### PR TITLE
send uploader up to parent compnent has access to it

### DIFF
--- a/addon/components/pl-uploader.js
+++ b/addon/components/pl-uploader.js
@@ -134,6 +134,9 @@ export default Ember.Component.extend({
     var queue = uploader.findOrCreate(get(this, 'name'), this, get(this, 'config'));
     set(this, 'queue', queue);
 
+    var pluploader = queue.get('queues').objectAt(0);
+    this.sendAction('onInitOfUploader', pluploader);
+
     this._firstDragEnter = false;
     this._secondDragEnter = false;
     this._invalidateDragData();


### PR DESCRIPTION
so the controller or component that implments pl-uploader has access to the `uploader` object. This is so we can manually add files by doing `uploader.addFile`
